### PR TITLE
fix: add new qwik book-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@
 
 ### ⚡️ Qwik
 
-- [Qwik: Desde cero a producción](https://anartz-mugika.com/qwik-book/es/) - Anartz Mugika (HTML)
+- [Qwik: Desde cero a producción]([https://anartz-mugika.com/qwik-book/es/](https://qwik-book-spanish.netlify.app/)) - Anartz Mugika (HTML)
 
 ## Herramientas
 


### PR DESCRIPTION
Cambio de URL debido a que la que está actualmente publicada, dejará de estar disponible por dar de baja el dominio