### PR TITLE
docs: fix typo 'bibiliotecas' → 'bibliotecas'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
     - [🤖 Kotlin](#-kotlin)
     - [☕ Java](#-java)
     - [📊 R](#-r)
-  - [Frameworks y bibiliotecas](#frameworks-y-bibiliotecas)
+  - [Frameworks y bibliotecas](#frameworks-y-bibliotecas)
     - [⚛️ React](#️-react)
     - [⚡️ Qwik](#️-qwik)
   - [Herramientas](#herramientas)
@@ -104,7 +104,7 @@
 
 - [R para Ciencia de Datos](https://es.r4ds.hadley.nz/) - Hadley Wickham y Garrett Grolemund (HTML)
 
-## Frameworks y bibiliotecas
+## Frameworks y bibliotecas
 
 ### ⚛️ React
 


### PR DESCRIPTION
### Summary
- Fixed a small typo: "bibiliotecas" → "bibliotecas" in both the index link and the section title.

### Why
- Improves readability and ensures that the index anchor matches the section header.
- Small but important change to keep documentation clean and professional.

### Checklist
- [x] Forked repository
- [x] Created a new branch `docs-fix-typo`
- [x] Edited README.md
- [x] Committed and pushed branch
- [x] Opened this pull request
