### PR TITLE
docs: completa formatos faltantes en el catálogo

### DIFF
--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -79,6 +79,7 @@ export const librarySections: LibrarySection[] = [
         title: 'Los apuntes de Majo',
         href: 'https://losapuntesdemajo.vercel.app/',
         author: 'Majo Ledesma',
+        formats: ['HTML'],
       },
     ],
   },
@@ -285,6 +286,7 @@ export const librarySections: LibrarySection[] = [
         title: 'Manual de TypeScript',
         href: 'https://mega.nz/#!qwcFDZ7a!ggLXIZ4c-O1Do0OEuvK0Mz8k39LvYQwdaJ2LtKKxgsE',
         author: 'Emmanuel Valverde y Pedro Hernández-Mora',
+        formats: ['eBook'],
       },
       {
         title: 'Uso avanzado de TypeScript en un ejemplo real',
@@ -572,6 +574,7 @@ export const librarySections: LibrarySection[] = [
         title: 'Go en Español',
         href: 'https://nachopacheco.gitbooks.io/go-es/content/doc',
         author: 'Nacho Pacheco',
+        formats: ['HTML'],
       },
     ],
   },
@@ -953,11 +956,13 @@ export const librarySections: LibrarySection[] = [
         title: 'Tutorial de SQL',
         href: 'http://www.desarrolloweb.com/manuales/9/',
         author: 'Rubén Alvarez',
+        formats: ['HTML'],
       },
       {
         title: 'Manual de SQL',
         href: 'http://jorgesanchez.net/manuales/sql/intro-sql-sql2016.html',
         author: 'Jorge Sanchez Asenjo',
+        formats: ['HTML'],
       },
       {
         title: 'Apuntes básicos de SQL',


### PR DESCRIPTION
## Resumen

- Añade `formats` a cinco recursos del catálogo que no tenían formato declarado.
- Mejora la consistencia visual de las etiquetas de formato en el catálogo.
- Completa metadatos usados para SEO, incluyendo `encodingFormat`.

## Cambios

| Archivo | Cambio |
|---|---|
| `web/src/data/library.ts` | Añade `formats` a recursos HTML y eBook faltantes |

## Validación

- [x] `pnpm -C web build`
- [x] Check local-only del catálogo: 112 libros revisados, 0 sin `formats`
- [x] Revisión manual del diff