### PR TITLE
Añade Full Stack Open y Clean Code JavaScript en Español

### DIFF
--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -248,6 +248,23 @@ export const librarySections: LibrarySection[] = [
         author: 'Jordi Collell Puig',
         formats: ['PDF'],
       },
+      {
+        title: 'Full Stack Open',
+        href: 'https://fullstackopen.com/es/',
+        author:
+          'Universidad de Helsinki, traducido al español por Sebastian Torres, Cynthia Vico Vacca y Pablo Maffioli',
+        formats: ['HTML'],
+        note:
+          'Curso full-stack moderno basado en JavaScript con React, Node.js, MongoDB, GraphQL y TypeScript. La parte 11 de CI/CD está disponible en inglés.',
+      },
+      {
+        title: 'Clean Code JavaScript en Español',
+        href: 'https://github.com/andersontr15/clean-code-javascript-es',
+        author: 'Ryan McDermott, traducido al español por Theodore Anderson',
+        formats: ['HTML'],
+        note:
+          'Guía práctica de buenas prácticas para JavaScript: variables, funciones, clases, SOLID, pruebas, concurrencia, manejo de errores, formato y comentarios.',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Descripción

Aquí dos recursos gratuitos en español que creo que pueden aportar bastante valor a la sección de JavaScript:

- Full Stack Open en Español
- Clean Code JavaScript en Español

Los añadí como recursos HTML y enlazando directamente a sus fuentes oficiales.

## ¿Por qué estos recursos?

Full Stack Open es un curso bastante completo para aprender desarrollo full-stack moderno con JavaScript, React, Node.js, MongoDB, GraphQL y TypeScript. También dejé una nota aclarando que la parte 11 de CI/CD está disponible en inglés.

Clean Code JavaScript en Español es una guía práctica para escribir código JavaScript más limpio, reutilizable y fácil de mantener, con temas como funciones, clases, SOLID, testing, concurrencia, manejo de errores y comentarios.

## Validación

- `pnpm build` ✅
- `pnpm check:links` ✅

## Notas

Revisé que ambos recursos fueran gratuitos, estuvieran disponibles en español y apuntaran a fuentes oficiales.

No se añadió ningún PDF externo, copia ni mirror del contenido.