### PR TITLE
fix: ignora contenido inline en check-links

### DIFF
--- a/web/scripts/check-links.mjs
+++ b/web/scripts/check-links.mjs
@@ -154,8 +154,22 @@ function parseAttributes(rawAttributes = '') {
   return attributes;
 }
 
+function preserveLineBreaks(value) {
+  return value.replace(/[^\n]/g, '');
+}
+
+function stripRawTextElementContent(html) {
+  return html.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, (match) => {
+    const openingTag = match.match(/^<[^>]*>/)?.[0] ?? '';
+    const closingTag = match.match(/<\/(?:script|style)>$/i)?.[0] ?? '';
+    const content = match.slice(openingTag.length, match.length - closingTag.length);
+
+    return `${openingTag}${preserveLineBreaks(content)}${closingTag}`;
+  });
+}
+
 function extractLinks(htmlFile, rootDir) {
-  const html = readFileSync(htmlFile, 'utf8');
+  const html = stripRawTextElementContent(readFileSync(htmlFile, 'utf8'));
   const source = relative(rootDir, htmlFile);
   const links = [];
   const tagPattern = /<([a-z][\w:-]*)(\s[^<>]*?)?>/gi;


### PR DESCRIPTION
## Descripción

Corrige un falso positivo del verificador de enlaces cuando encuentra HTML dentro de strings de JavaScript inline.

El caso actual detectaba `${e.href}` como si fuera un enlace interno real en `index.html`, aunque el valor viene de un template string generado dentro de un script.

Closes #58

## Cambios

- Ignora el contenido interno de `<script>` y `<style>` al extraer enlaces.
- Mantiene los tags de apertura y cierre para conservar enlaces reales en atributos como `src`.
- Conserva saltos de línea para mantener números de línea útiles en reportes.

## Validación

- `pnpm build` ✅
- `pnpm check:links` ✅