### PR TITLE
Fix broken book links

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Pensamiento funcional duro y puro para expandir cómo entiendes el código.
 Concurrencia, simplicidad y tooling impecable para servicios y utilidades.
 
 - [El pequeño libro de Go](https://librosgratis.dev/books/go-pequeno-libro.pdf) — Karl Seguin, traducido por Raúl Exposito · PDF
-- [Go en Español](https://nachopacheco.gitbooks.io/go-es/content/doc) — Nacho Pacheco
+- [Go en Español](https://nachopacheco.gitbooks.io/go-es/content/doc/) — Nacho Pacheco
 
 ## Kotlin
 

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -443,8 +443,7 @@ export const librarySections: LibrarySection[] = [
       {
         id: 'introduccion-a-la-programacion-con-python-3',
         title: 'Introducción a la programación con Python 3',
-        href: 'https://repositori.uji.es/items/992c7ee2-fef4-4061-9958-aefe932fd611',
-        pdfHref: '/books/python-introduccion-programacion-3.pdf',
+        href: '/books/python-introduccion-programacion-3.pdf',
         author: 'Andrés Marzal Varó, Isabel Gracia Luengo, Pedro García-Sevilla',
         formats: ['PDF'],
       },
@@ -673,7 +672,7 @@ export const librarySections: LibrarySection[] = [
       {
         id: 'go-en-espanol',
         title: 'Go en Español',
-        href: 'https://nachopacheco.gitbooks.io/go-es/content/doc',
+        href: 'https://nachopacheco.gitbooks.io/go-es/content/doc/',
         author: 'Nacho Pacheco',
         formats: ['HTML'],
       },
@@ -738,8 +737,7 @@ export const librarySections: LibrarySection[] = [
       {
         id: 'c-introduccion-a-la-programacion-con-c',
         title: 'Introducción a la Programación con C',
-        href: 'https://repositori.uji.es/items/3bd580d8-8def-470b-a053-164dc98f3d9e',
-        pdfHref: '/books/c-introduccion-programacion.pdf',
+        href: '/books/c-introduccion-programacion.pdf',
         author: 'Andrés Marzal Varó, Isabel Gracia Luengo',
         formats: ['PDF'],
       },


### PR DESCRIPTION
## Resumen
- Usa la URL canónica con `/` final para `Go en Español`.
- Cambia los libros de Python 3 y C de las páginas de `repositori.uji.es` a los PDFs locales que ya están publicados en el sitio.
- Mantiene el README coherente con la URL canónica de Go.

Closes #66.
Closes #75.

## Verificación
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `Invoke-WebRequest` confirma `https://nachopacheco.gitbooks.io/go-es/content/doc/` con HEAD y GET `200`.
- Confirmé que `web/dist/client/books/python-introduccion-programacion-3.pdf` y `web/dist/client/books/c-introduccion-programacion.pdf` existen tras el build.
- Confirmé que ya no quedan referencias a `repositori.uji.es` ni a la URL de Go sin `/` en `README.md`, `web/src` ni `web/dist`.

Nota: `node ./scripts/check-links.mjs --timeout=5000 --concurrency=32` llegó a colgarse por comprobaciones externas de red. Antes del cambio reportaba exactamente los cuatro enlaces de `repositori.uji.es` como rotos; después del cambio esos enlaces ya no aparecen en el build.