### PR TITLE
Añade apuntes GH-600 (GitHub Agentic AI Developer) en IA

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Biblioteca viva de libros y guías gratuitas de programación en español. El ca
 
 - Web: [librosgratis.dev](https://librosgratis.dev)
 - Repositorio fuente original: [midudev/libros-programacion-gratis](https://github.com/midudev/libros-programacion-gratis)
-- Total actual: 115 recursos en 32 secciones
+- Total actual: 116 recursos en 32 secciones
 
 ## Categorías
 
@@ -15,7 +15,7 @@ Biblioteca viva de libros y guías gratuitas de programación en español. El ca
 - Frameworks: 9 recursos en 5 secciones
 - Herramientas: 8 recursos en 3 secciones
 - Bases de datos: 6 recursos en 2 secciones
-- IA y datos: 1 recurso en 1 sección
+- IA y datos: 2 recursos en 1 sección
 
 ## Índice
 
@@ -49,7 +49,7 @@ Biblioteca viva de libros y guías gratuitas de programación en español. El ca
 - [SQL](#sql) · 4
 - [NoSQL](#nosql) · 2
 - [Sistemas operativos](#sistemas-operativos) · 1
-- [Inteligencia Artificial](#ia) · 1
+- [Inteligencia Artificial](#ia) · 2
 - [Metodologías de desarrollo](#metodologias) · 2
 
 ## Generales
@@ -381,6 +381,7 @@ Procesos, memoria, archivos y concurrencia para entender qué hay debajo del sta
 Fundamentos de aprendizaje automático, agentes y razonamiento computacional.
 
 - [Inteligencia Artificial: un enfoque moderno](https://iaarbook.github.io/) — Peter Norvig y Stuart Russell, adaptación abierta · HTML
+- [Apuntes GH-600: GitHub Agentic AI Developer](https://matiasbeltramone.com/apuntes/github-agentic-ai/) — Matías Beltramone · HTML
 
 ## Metodologías de desarrollo
 

--- a/web/src/data/library.ts
+++ b/web/src/data/library.ts
@@ -1176,6 +1176,13 @@ export const librarySections: LibrarySection[] = [
         author: 'Peter Norvig y Stuart Russell, adaptación abierta',
         formats: ['HTML'],
       },
+      {
+        id: 'apuntes-gh-600-github-agentic-ai',
+        title: 'Apuntes GH-600: GitHub Agentic AI Developer',
+        href: 'https://matiasbeltramone.com/apuntes/github-agentic-ai/',
+        author: 'Matías Beltramone',
+        formats: ['HTML'],
+      },
     ],
   },
   {


### PR DESCRIPTION
Agrega en la sección **Inteligencia Artificial** un cuaderno de apuntes gratuito y en español sobre la certificación GH-600 (GitHub Certified: Agentic AI Developer), enfocado en agentes de IA.

- Recurso: https://matiasbeltramone.com/apuntes/github-agentic-ai/

Son apuntes estructurados y autocontenidos (formato cuaderno, HTML), no un artículo de blog: cubren los 6 dominios del temario con teoría y un LAB por dominio. Encaja con la descripción de la sección ("agentes y razonamiento computacional").

Cambios: entrada en `web/src/data/library.ts` (fuente) + reflejo en `README.md`, con los contadores actualizados (115 → 116, IA 1 → 2). Cumple las reglas: español, gratis, HTML.